### PR TITLE
Prevent users from setting a profile security level lower than their own

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -8,6 +8,7 @@ use Illuminate\Validation\Rule;
 use DB;
 use Log;
 use Auth;
+use Validator;
 
 class ProfileController extends Controller
 {
@@ -207,9 +208,10 @@ class ProfileController extends Controller
      *
      * @param array $fields Fields to include in rules, null for all
      * @param array $knight Knight being edited, null if being created
+     * @param int $min_sec  Minimum security level
      * @return array        Array of rules
      */
-    private static function getRules($fields = null, $knight = null) {
+    private static function getRules($fields = null, $knight = null, $min_sec = 0) {
         if ($knight) {
             $unique = Rule::unique('knight')->ignore($knight->rname, 'rname');
         } else {
@@ -241,7 +243,12 @@ class ProfileController extends Controller
             ],
             'batt' => 'required|integer|exists:battalion,pkey',
             'rank' => 'required|integer|exists:krank,pkey',
-            'security' => 'required|integer|exists:security,pkey',
+            'security' => [
+                'required',
+                'integer',
+                'exists:security,pkey',
+                'min:' . $min_sec
+            ],
             'divs' => 'nullable',
             'divs.*' => 'integer|exists:division,pkey',
             'firstevent' => 'nullable|integer|exists:event,pkey',
@@ -257,6 +264,17 @@ class ProfileController extends Controller
         } else {
             return $all_rules;
         }
+    }
+
+    /**
+     * Generate validation messages
+     *
+     * @return array Array of messages
+     */
+    private static function getMessages() {
+        return [
+            'security.min' => 'You cannot set a security level higher than your own!',
+        ];
     }
 
     /**
@@ -339,7 +357,14 @@ class ProfileController extends Controller
             abort(401, 'Not authorized to edit knight.');
         }
 
-        $validated = $request->validate($this->getRules($editable_fields, $knight));
+        $validator = Validator::make(
+            $request->all(),
+            // Ensure
+            $this->getRules($editable_fields, $knight, Auth::user()->security),
+            $this->getMessages()
+        );
+
+        $validated = $validator->validate();
 
         // Start transaction
         DB::transaction(function () use (&$validated, &$rname, &$knight) {

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -82,7 +82,7 @@
                     </div>
                 </div>
                 @endif
-                {{-- @if (in_array('security', $editable_fields))
+                @if (in_array('security', $editable_fields))
                 <div class="col-sm">
                     <div class="form-group">
                         <label>Security</label>
@@ -96,7 +96,7 @@
                         </select>
                     </div>
                 </div>
-                @endif --}}
+                @endif
             </div>
             <div class="row">
                 @if (in_array('divs', $editable_fields))


### PR DESCRIPTION
Closes #62.

Perhaps this should instead be limited to one level above their own?